### PR TITLE
Set the "Archives" link to the right radio station.

### DIFF
--- a/src/background/controller.js
+++ b/src/background/controller.js
@@ -243,8 +243,8 @@ export default class Background {
 
       const station = preferences.get('playback.station');
       const quality = preferences.get('playback.quality');
-
       this.radio.setPlaybackUrl(getStationFeed(station, quality));
+      this.radio.reload();
       this.requestBroadcasts();
     }
   }

--- a/src/lib/radio.js
+++ b/src/lib/radio.js
@@ -82,6 +82,16 @@ const Radio = machina.Fsm.extend({
     this.handle('play');
   },
   /**
+   * Reload the radio
+   * @api
+   */
+  "reload": function(){
+    if (this.state !== 'stopped') {
+      this.stop();
+      this.play();
+    }
+  },
+  /**
    * Stop the radio
    * @api
    */

--- a/src/lib/stations.js
+++ b/src/lib/stations.js
@@ -14,3 +14,9 @@ export function getStationFeed (station, quality) {
 
   return streams[quality] ? streams[quality] : streams['sd'];
 }
+
+export function getStationArchiveUrl(station) {
+  const {archives} = stations[station];
+
+  return archives;
+}

--- a/src/now-playing/broadcast-controller.js
+++ b/src/now-playing/broadcast-controller.js
@@ -1,4 +1,5 @@
 import Broadcast from '../lib/broadcast.js';
+import {getStationArchiveUrl} from '../lib/stations.js';
 
 /**
  * Now Playing Controller.
@@ -10,6 +11,9 @@ import Broadcast from '../lib/broadcast.js';
  */
 export default function BroadcastController($scope, chrome, preferences){
   const getPosition = Broadcast.getPositionTracker();
+  const station = preferences.get('playback.station', 'fip-paris');
+
+  $scope.archives_url = getStationArchiveUrl(station);
 
   $scope.broadcasts = preferences.get('broadcasts');
   $scope.current_index = getPosition($scope.broadcasts, null);

--- a/src/now-playing/index.html
+++ b/src/now-playing/index.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="popup.css"/>
   <link rel="stylesheet" href="../resources/icons/css/fontello-embedded.css"/>
 </head>
-<body>
+<body ng-controller="BroadcastController">
 
 <header ng-controller="RadioController">
   <h1>{{'extension_name' | i18n}}</h1>
@@ -14,7 +14,7 @@
   <button type="button" id="playback-button" class="icon-state" ng-click="toggle()" ng-class="status" tabindex="1"></button>
 </header>
 
-<main ng-controller="BroadcastController">
+<main>
   <div class="tiles" data-current-index="{{current_index}}" style="--current-index:{{current_index}};">
     <section ng-repeat="(index,broadcast) in broadcasts" class="status-{{broadcast | status}}" ng-class="{show: current_index === index}">
       <aside class="panel" id="cover">
@@ -70,7 +70,7 @@
   <nav>
     <ul>
       <li class="main">
-        <a href="https://www.fip.fr/archives-antenne" class="iconify" target="_blank">{{'archives' | i18n}}</a>
+        <a ng-href="{{archives_url}}" class="iconify" target="_blank">{{'archives' | i18n}}</a>
       </li>
       <li>
         <a href="#settings">{{ 'change_settings' | i18n }}</a>

--- a/src/options/options-controller.js
+++ b/src/options/options-controller.js
@@ -17,11 +17,16 @@ export default function OptionsController($scope, chrome, preferences, $timeout)
   $scope.lastfm_enabled = lastFm.isEnabled();
 
   $scope.save = function(){
+    const prevStation = preferences.get('playback.station', 'fip-paris');
+    const prevQuality = preferences.get('playback.quality', 'hd');
+
     $scope.saveStatus = 'saved';
     preferences.set('playback.station', $scope.currentStation);
     preferences.set('playback.quality', $scope.quality);
 
-    chrome.notify('playback.reload');
+    if ($scope.currentStation !== prevStation || $scope.quality !== prevQuality) {
+      chrome.notify('playback.reload');
+    }
 
     $timeout(() => $scope.saveStatus = 'idle', 2000);
   };

--- a/src/stations.json
+++ b/src/stations.json
@@ -2,6 +2,7 @@
   "fip-paris": {
     "name": "Paris",
     "channelId": 7,
+    "archives": "https://www.fip.fr/archives-antenne",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-lofi.mp3",
       "hd": "https://direct.fipradio.fr/live/fip-midfi.mp3"
@@ -10,6 +11,7 @@
   "fip-bordeaux": {
     "name": "Bordeaux",
     "channelId": 7,
+    "archives": "https://www.fip.fr/archives-antenne",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fipbordeaux-lofi.mp3",
       "hd": "https://direct.fipradio.fr/live/fipbordeaux-midfi.mp3"
@@ -18,6 +20,7 @@
   "fip-nantes": {
     "name": "Nantes",
     "channelId": 7,
+    "archives": "https://www.fip.fr/archives-antenne",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fipnantes-lofi.mp3",
       "hd": "https://direct.fipradio.fr/live/fipnantes-midfi.mp3"
@@ -26,6 +29,7 @@
   "fip-strasbourg": {
     "name": "Strasbourg",
     "channelId": 7,
+    "archives": "https://www.fip.fr/archives-antenne",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fipstrasbourg-lofi.mp3",
       "hd": "https://direct.fipradio.fr/live/fipstrasbourg-midfi.mp3"
@@ -34,6 +38,7 @@
   "theme-electro": {
     "name": "Autour de l'électro",
     "channelId": 74,
+    "archives": "https://www.fip.fr/archives-antenne/74",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio8.mp3"
     }
@@ -41,6 +46,7 @@
   "theme-rock": {
     "name": "Autour du rock",
     "channelId": 64,
+    "archives": "https://www.fip.fr/archives-antenne/64",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio1.mp3"
     }
@@ -48,6 +54,7 @@
   "theme-jazz": {
     "name": "Autour du jazz",
     "channelId": 65,
+    "archives": "https://www.fip.fr/archives-antenne/65",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio2.mp3"
     }
@@ -55,6 +62,7 @@
   "theme-groove": {
     "name": "Autour du groove",
     "channelId": 66,
+    "archives": "https://www.fip.fr/archives-antenne/66",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio3.mp3"
     }
@@ -62,6 +70,7 @@
   "theme-monde": {
     "name": "Autour du monde",
     "channelId": 69,
+    "archives": "https://www.fip.fr/archives-antenne/69",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio4.mp3"
     }
@@ -69,6 +78,7 @@
   "theme-nouveau": {
     "name": "Tout nouveau, tout FIP",
     "channelId": 70,
+    "archives": "https://www.fip.fr/archives-antenne/70",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio5.mp3"
     }
@@ -76,6 +86,7 @@
   "theme-reggae": {
     "name": "Autour du reggae",
     "channelId": 71,
+    "archives": "https://www.fip.fr/archives-antenne/71",
     "streams": {
       "sd": "https://direct.fipradio.fr/live/fip-webradio6.mp3"
     }


### PR DESCRIPTION
"Archives" currently links to http://www.fipradio.fr/archives-antenne/ , but doesn't change if you choose another station.

Here are the links to the Webradios :

- fip autour de l'électro : http://www.fipradio.fr/archives-antenne/74
- fip autour du rock : http://www.fipradio.fr/archives-antenne/64
- fip autour du jazz : http://www.fipradio.fr/archives-antenne/65
- fip autour du groove : http://www.fipradio.fr/archives-antenne/66
- fip autour du monde : http://www.fipradio.fr/archives-antenne/69
- Tout nouveau, tout fip : http://www.fipradio.fr/archives-antenne/70
- fip autour du reggae : http://www.fipradio.fr/archives-antenne/71

I couldn't find the archives for the regional stations, but I don't know if the playlist is different.